### PR TITLE
Fix wheel scroll in alternate screen when mouse tracking is enabled

### DIFF
--- a/src/vendor/ghostty-web/lib/terminal.ts
+++ b/src/vendor/ghostty-web/lib/terminal.ts
@@ -1403,21 +1403,28 @@ export class Terminal implements ITerminalCore {
    * Handle wheel events for scrolling (Phase 2)
    */
   private handleWheel = (e: WheelEvent): void => {
-    // Always prevent default browser scrolling
-    e.preventDefault();
-    e.stopPropagation();
-
     // Allow custom handler to override
     if (this.customWheelEventHandler && this.customWheelEventHandler(e)) {
+      e.preventDefault();
+      e.stopPropagation();
       return;
     }
 
-    // Check if in alternate screen mode (vim, less, htop, etc.)
     const isAltScreen = this.wasmTerm?.isAlternateScreen() ?? false;
 
+    // Apps in the alternate screen with mouse tracking enabled (e.g. Ink TUIs)
+    // expect SGR wheel sequences. InputHandler emits those on bubble; do not
+    // translate wheel into arrow keys or block propagation here.
+    if (isAltScreen && this.wasmTerm?.hasMouseTracking()) {
+      return;
+    }
+
+    // Always prevent default browser scrolling for terminal-owned wheel handling
+    e.preventDefault();
+    e.stopPropagation();
+
     if (isAltScreen) {
-      // Alternate screen: send arrow keys to the application
-      // Applications like vim handle scrolling internally
+      // Alternate screen without mouse tracking: send arrow keys (vim, less, etc.)
       // Standard: ~3 arrow presses per wheel "click"
       const direction = e.deltaY > 0 ? 'down' : 'up';
       const count = Math.min(Math.abs(Math.round(e.deltaY / 33)), 5); // Cap at 5


### PR DESCRIPTION
## Summary

When a full-screen TUI enables SGR mouse tracking (`?1000`, `?1002`, `?1006`), wheel events should reach the app as SGR wheel sequences (`\x1b[<64;…` / `\x1b[<65;…`), not as up/down arrow keys.

Bump's capture-phase `handleWheel` always translated scroll to `\x1b[A` / `\x1b[B` in alternate-screen mode and called `stopPropagation()`, so `InputHandler.handleWheel` never ran. Apps that scroll via mouse wheel (e.g. Cursor agent-cli transcript viewport) instead saw arrow keys hit the focused prompt and cycle command history.

## Fix

In `terminal.ts` `handleWheel`:

- If alternate screen **and** mouse tracking are active, return early without `preventDefault`/`stopPropagation` so `InputHandler` can emit SGR wheel events.
- Otherwise keep existing behavior: arrow keys for alt-screen apps without mouse tracking (vim, less, etc.), viewport scroll on the normal screen.

```text
wheel event (capture on parent)
  ├─ alt screen + mouse tracking? → return (bubble → InputHandler → SGR wheel)
  ├─ alt screen, no mouse tracking? → fire ESC [ A/B
  └─ normal screen → smooth viewport scroll
```

## Test plan

- [ ] Run agent-cli (or another Ink TUI with mouse tracking) in Bump; scroll over the transcript — transcript scrolls, prompt history does not cycle.
- [ ] In alternate screen without mouse tracking (e.g. `vim`, `less`), wheel still sends arrow keys as before.
- [ ] On the normal screen, wheel still scrolls terminal scrollback/history.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wheel-event suppression/translation in `terminal.ts`, which can affect scrolling and input behavior across TUIs; risk is moderate due to event propagation nuances but scoped to wheel handling.
> 
> **Overview**
> Fixes mouse-wheel behavior in alternate-screen TUIs with mouse tracking enabled by **stopping capture-phase `handleWheel` from `preventDefault`/`stopPropagation` and from translating wheel into up/down arrows** when `isAlternateScreen && hasMouseTracking`.
> 
> For other cases, behavior is preserved: custom wheel handlers still short-circuit with default prevention, alternate-screen apps without mouse tracking still receive arrow-key sequences, and normal-screen wheel scrolling still prevents browser scrolling and scrolls the viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4127712c404030a3d46e462844daecc6b2a56fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->